### PR TITLE
fix boundless tempfs usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+My own fork of pixcat, changing only the cleanup of temporary files. Pixcat under this fork will delete its temporary files after displaying them, preventing the saturation of your tmpfs.
+
+Original README below, links are not edited and go to the original repo's links:
+
 # pixcat
 
 [![PyPI downloads](http://pepy.tech/badge/pixcat)](

--- a/pixcat/__about__.py
+++ b/pixcat/__about__.py
@@ -4,7 +4,7 @@
 """Display images on a kitty terminal with optional resizing."""
 
 __pkg_name__ = "pixcat"
-__version__  = "0.1.4"
+__version__  = "0.1.5"
 __status__   = "Development"
 # __status__ = "Production"
 

--- a/pixcat/terminal.py
+++ b/pixcat/terminal.py
@@ -1,6 +1,7 @@
 import array
 import base64
 import fcntl
+import os
 import signal
 import sys
 import termios
@@ -107,6 +108,16 @@ class PixTerminal(blessed.Terminal):
         if answer and ";OK" not in answer:
             raise KittyAnswerError(code, answer)
 
+        try:
+            # Remove temp file to avoid using excess recourses, normally not
+            # necessary but repeated calls to pixact multiple times a second
+            # will (relatively) quickly cause further attempts to make temporary
+            # files to fail.
+            os.remove(payload)
+        except FileNotFoundError:
+            # This should not occure, but if by chance someone did pixcat's job
+            # for it we aren't going to complain about it.
+            return
 
     def detect_support(self) -> bool:
         try:

--- a/pixcat/terminal.py
+++ b/pixcat/terminal.py
@@ -105,9 +105,6 @@ class PixTerminal(blessed.Terminal):
 
         answer = "".join(chars)
 
-        if answer and ";OK" not in answer:
-            raise KittyAnswerError(code, answer)
-
         try:
             # Remove temp file to avoid using excess recourses, normally not
             # necessary but repeated calls to pixact multiple times a second
@@ -117,7 +114,10 @@ class PixTerminal(blessed.Terminal):
         except FileNotFoundError:
             # This should not occure, but if by chance someone did pixcat's job
             # for it we aren't going to complain about it.
-            return
+            pass
+
+        if answer and ";OK" not in answer:
+            raise KittyAnswerError(code, answer)
 
     def detect_support(self) -> bool:
         try:

--- a/pixcat/terminal.py
+++ b/pixcat/terminal.py
@@ -119,6 +119,7 @@ class PixTerminal(blessed.Terminal):
         if answer and ";OK" not in answer:
             raise KittyAnswerError(code, answer)
 
+
     def detect_support(self) -> bool:
         try:
             # Send an useless code that will force a response out of kitty,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         ]
     },
 
-    url      = "https://github.com/mirukan/pixcat",
+    url      = "https://github.com/an-prata/pixcat",
     keywords = "kitty api cli terminal print display resize scale image " \
                "picture graphic icat",
 


### PR DESCRIPTION
Using [miniplayer](https://github.com/GuardKenzie/miniplayer), which uses pixcat to display album art, I noticed that the number of `.pixcat-*` files in `/tmp/` would only increase. I believe this was also the cause of a crash, in which an exception was thrown due to not being able to create another temporary file, running `rm /tmp/.pixcat-*` resolved the issue in that case but I was unable to recreate it (this was after miniplayer was open for a couple days on my laptop).

You can easiy confirm that pixcat doesnt remove its temporary files with this simple script on a Unix system (though be cautious of how long you run it, saturating the tmpfs completely will crash your system if I'm not mistaken):
```python
#!/usr/bin/env python

import pixcat
import os

# An image file I use for a wallpaper sometimes, replace for other systems.
SOME_MEDIUM_SIZE_FILE = "/usr/share/backgrounds/Sunset.png"

while True:
    pixcat.Image(SOME_MEDIUM_SIZE_FILE).thumbnail().show()
    os.system("ls /tmp/.pixcat-* | wc")
```

This PR has pixcat call `os.remove()` on `payload` as it is given to `PixTerminal.run_code()` after receiving a full response from kitty.
